### PR TITLE
게시판 검색 구현

### DIFF
--- a/src/main/java/com/fastcapmus/board/controller/ArticleController.java
+++ b/src/main/java/com/fastcapmus/board/controller/ArticleController.java
@@ -50,6 +50,7 @@ public class ArticleController {
 
         modelMap.addAttribute("articles", articles);
         modelMap.addAttribute("paginationBarNumbers", barNumber);
+        modelMap.addAttribute("searchTypes", SearchType.values());
 
         log.info(modelMap.get("articles").toString());
         return "articles/index";

--- a/src/main/java/com/fastcapmus/board/domain/type/SearchType.java
+++ b/src/main/java/com/fastcapmus/board/domain/type/SearchType.java
@@ -1,10 +1,18 @@
 package com.fastcapmus.board.domain.type;
 
-public enum SearchType {
-    TITLE,
-    CONTENT,
-    ID,
-    NICKNAME,
-    HASHTAG
+import lombok.Getter;
 
+public enum SearchType {
+    TITLE("제목"),
+    CONTENT("내용"),
+    ID("유저ID"),
+    NICKNAME("작성자"),
+    HASHTAG("해시태그");
+
+    @Getter
+    private final String description;
+
+    SearchType(String description) {
+        this.description = description;
+    }
 }

--- a/src/main/resources/templates/articles/index.html
+++ b/src/main/resources/templates/articles/index.html
@@ -23,7 +23,7 @@
     <div class="row">
         <div class="card card-margin search-form">
             <div class="card-body p-0">
-                <form id="search-form">
+                <form action="/articles" method="get">
                     <div class="row">
                         <div class="col-12">
                             <div class="row no-gutters">

--- a/src/test/java/com/fastcapmus/board/controller/ArticleControllerTest.java
+++ b/src/test/java/com/fastcapmus/board/controller/ArticleControllerTest.java
@@ -1,6 +1,7 @@
 package com.fastcapmus.board.controller;
 
 import com.fastcapmus.board.config.SecurityConfig;
+import com.fastcapmus.board.domain.type.SearchType;
 import com.fastcapmus.board.dto.ArticleWithCommentsDto;
 import com.fastcapmus.board.dto.UserAccountDto;
 import com.fastcapmus.board.service.ArticleService;
@@ -59,9 +60,33 @@ class ArticleControllerTest {
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
                 .andExpect(view().name("articles/index"))
                 .andExpect(model().attributeExists("articles"))
-                .andExpect(model().attributeExists("paginationBarNumbers"));
+                .andExpect(model().attributeExists("paginationBarNumbers"))
+                .andExpect(model().attributeExists("searchTypes"));
 
         then(articleService).should().searchArticles(eq(null), eq(null), any(Pageable.class));
+        then(paginationService).should().getPaginationBarNumbers(anyInt(), anyInt());
+    }
+
+    @DisplayName("[view][GET] 게시글 리스트 페이지 - 검색어와 함께 호출")
+    @Test
+    public void givenSearchKeyword_requestSearchingArticlesView_thenReturnArticlesView() throws Exception {
+        // Given
+        SearchType searchType = SearchType.TITLE;
+        String searchValue = "title";
+        given(articleService.searchArticles(eq(searchType), eq(searchValue), any(Pageable.class))).willReturn(Page.empty());
+        given(paginationService.getPaginationBarNumbers(anyInt(), anyInt())).willReturn(List.of(0, 1, 2, 3, 4));
+
+        // When & Then
+        mvc.perform(get("/articles")
+                        .queryParam("searchType", searchType.name())
+                        .queryParam("searchValue", searchValue))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("articles/index"))
+                .andExpect(model().attributeExists("articles"))
+                .andExpect(model().attributeExists("searchTypes"));
+
+        then(articleService).should().searchArticles(eq(searchType), eq(searchValue), any(Pageable.class));
         then(paginationService).should().getPaginationBarNumbers(anyInt(), anyInt());
     }
 


### PR DESCRIPTION
게시판에서 게시글을 검색하는 기능을 구현하고 테스트 함.

- 검색 대상 필드로 기본 검색 기능 구현
- 기본 게시판 페이지의 검색 바 기능 구현
* 해시태그 검색은 따로 구현하기로 함-> https://github.com/bluesky3268/fastcamp_board/issues/36

This closes #28 