### PR TITLE
#31 인증 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-rest'
     implementation 'org.springframework.data:spring-data-rest-hal-explorer'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf' // Thymeleaf 의존성 추가
-    implementation  'org.springframework.boot:spring-boot-starter-security' // spring security 의존성 추가
-    implementation  'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'// spring security 관련 의존성 추가
+    implementation 'org.springframework.boot:spring-boot-starter-security' // spring security 의존성 추가
+//    implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'// spring security 관련 의존성 추가
+    implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 
     /** Querydsl 설정 */
     // spring boot 3.0 미만

--- a/src/main/java/com/fastcapmus/board/config/JpaConfig.java
+++ b/src/main/java/com/fastcapmus/board/config/JpaConfig.java
@@ -1,9 +1,13 @@
 package com.fastcapmus.board.config;
 
+import com.fastcapmus.board.dto.security.BoardPrincipal;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.util.Optional;
 
@@ -13,6 +17,11 @@ public class JpaConfig {
 
     @Bean
     public AuditorAware<String> auditorAware() {
-        return () -> Optional.of("hyunbenny");
+        return () -> Optional.ofNullable(SecurityContextHolder.getContext())
+                .map(SecurityContext::getAuthentication)
+                .filter(Authentication::isAuthenticated)
+                .map(Authentication::getPrincipal)
+                .map(BoardPrincipal.class::cast)
+                .map(BoardPrincipal::getUsername);
     }
 }

--- a/src/main/java/com/fastcapmus/board/config/SecurityConfig.java
+++ b/src/main/java/com/fastcapmus/board/config/SecurityConfig.java
@@ -1,8 +1,19 @@
 package com.fastcapmus.board.config;
 
+
+import com.fastcapmus.board.dto.UserAccountDto;
+import com.fastcapmus.board.dto.security.BoardPrincipal;
+import com.fastcapmus.board.repository.UserAccountRepository;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -16,8 +27,41 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
-                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+//                        .mvcMatchers( // spring boot 3.0이상부터는 deprecated되었음.
+                        .requestMatchers(
+                                HttpMethod.GET,
+                                "/",
+                                "/articles",
+                                "/articles/search-hashtag"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
                 .formLogin().and()
+                .logout()
+                .logoutSuccessUrl("/")
+                .and()
                 .build();
+    }
+
+//    @Bean
+//    public WebSecurityCustomizer webSecurityCustomizer() {
+//        // 여기 등록된 페이지들은 spring security 검사에서 제외한다 -> static resource들을 등록한다. (css, js등)
+//        return (web) -> web.ignoring().requestMatchers(PathRequest.toStaticResources().atCommonLocations());
+//    }
+
+    @Bean
+    public UserDetailsService userDetailsService(UserAccountRepository userAccountRepository) {
+        return username -> userAccountRepository
+                .findById(username)
+                .map(UserAccountDto::from)
+                .map(BoardPrincipal::from)
+                .orElseThrow(() -> new UsernameNotFoundException("해당 유저를 찾을 수 없습니다 - username: " + username));
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
 }

--- a/src/main/java/com/fastcapmus/board/controller/ArticleCommentController.java
+++ b/src/main/java/com/fastcapmus/board/controller/ArticleCommentController.java
@@ -4,8 +4,10 @@ import com.fastcapmus.board.domain.UserAccount;
 import com.fastcapmus.board.dto.ArticleCommentDto;
 import com.fastcapmus.board.dto.UserAccountDto;
 import com.fastcapmus.board.dto.request.ArticleCommentRequest;
+import com.fastcapmus.board.dto.security.BoardPrincipal;
 import com.fastcapmus.board.service.ArticleCommentService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -24,9 +26,9 @@ public class ArticleCommentController {
      */
 
     @PostMapping("/new")
-    public String postNewArticleComment(ArticleCommentRequest request) {
-        //TODO : 인증 정보 추가 필요
-        articleCommentService.saveArticleComment(request.toDto(UserAccountDto.of("hyunbenny1", "1234", "hyunbenny1@mail.com", "hyunbenny1", "memo")));
+    public String postNewArticleComment(ArticleCommentRequest request,
+                                        @AuthenticationPrincipal BoardPrincipal boardPrincipal) {
+        articleCommentService.saveArticleComment(request.toDto(boardPrincipal.toDto()));
         return "redirect:/articles/" + request.articleId();
     }
 
@@ -35,9 +37,10 @@ public class ArticleCommentController {
      * 우회하는 방법도 있지만 http표준을 준수하기 위해서 사용하지 않기로 함.
      */
     @PostMapping("/{commentId}/delete")
-    public String deleteComment(@PathVariable Long commentId, Long articleId) {
-        //TODO : 인증 정보 추가 필요
-        articleCommentService.deleteArticleComment(commentId);
+    public String deleteComment(@PathVariable Long commentId,
+                                Long articleId,
+                                @AuthenticationPrincipal BoardPrincipal boardPrincipal) {
+        articleCommentService.deleteArticleComment(commentId, boardPrincipal.getUsername());
         return "redirect:/articles/" + articleId;
     }
 

--- a/src/main/java/com/fastcapmus/board/controller/ArticleController.java
+++ b/src/main/java/com/fastcapmus/board/controller/ArticleController.java
@@ -6,6 +6,7 @@ import com.fastcapmus.board.dto.UserAccountDto;
 import com.fastcapmus.board.dto.request.ArticleRequest;
 import com.fastcapmus.board.dto.response.ArticleResponse;
 import com.fastcapmus.board.dto.response.ArticleWithCommentsResponse;
+import com.fastcapmus.board.dto.security.BoardPrincipal;
 import com.fastcapmus.board.service.ArticleService;
 import com.fastcapmus.board.service.PaginationService;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.*;
@@ -91,10 +95,10 @@ public class ArticleController {
     }
 
     @PostMapping("/form")
-    public String postNewArticle(ArticleRequest articleRequest) {
-        // TODO : 인증 정보 추가 필요
-        articleService.saveArticle(articleRequest.toDto(UserAccountDto.of("hyunbenny1", "1234", "hyunbenny1@mail.com", "hyunbenny1", "memo")));
+    public String postNewArticle(ArticleRequest articleRequest,
+                                 @AuthenticationPrincipal BoardPrincipal boardPrincipal) {
 
+        articleService.saveArticle(articleRequest.toDto(boardPrincipal.toDto()));
         return "redirect:/articles";
     }
 
@@ -109,17 +113,20 @@ public class ArticleController {
     }
 
     @PostMapping ("/{articleId}/form")
-    public String updateArticle(@PathVariable Long articleId, ArticleRequest articleRequest) {
-        // TODO : 인증 정보 추가 필요
-        articleService.updateArticle(articleId, articleRequest.toDto(UserAccountDto.of("hyunbenny1", "1234", "hyunbenny1@mail.com", "hyunbenny1", "memo")));
+    public String updateArticle(@PathVariable Long articleId,
+                                ArticleRequest articleRequest,
+                                @AuthenticationPrincipal BoardPrincipal boardPrincipal) {
+        UserAccountDto userAccountDto = boardPrincipal.toDto();
+        articleService.updateArticle(articleId, articleRequest.toDto(userAccountDto));
 
         return "redirect:/articles/" + articleId;
     }
 
     @PostMapping ("/{articleId}/delete")
-    public String deleteArticle(@PathVariable Long articleId) {
-        // TODO : 인증 정보 추가 필요
-        articleService.deleteArticle(articleId);
+    public String deleteArticle(@PathVariable Long articleId,
+                                @AuthenticationPrincipal BoardPrincipal boardPrincipal) {
+//        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        articleService.deleteArticle(articleId, boardPrincipal.getUsername());
 
         return "redirect:/articles";
     }

--- a/src/main/java/com/fastcapmus/board/dto/response/ArticleCommentResponse.java
+++ b/src/main/java/com/fastcapmus/board/dto/response/ArticleCommentResponse.java
@@ -10,17 +10,18 @@ public record ArticleCommentResponse(
         String content,
         LocalDateTime createdAt,
         String email,
-        String nickname
+        String nickname,
+        String userId
 )implements Serializable {
 
-    public static ArticleCommentResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname) {
-        return new ArticleCommentResponse(id, content, createdAt, email, nickname);
+    public static ArticleCommentResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname, String userId) {
+        return new ArticleCommentResponse(id, content, createdAt, email, nickname, userId);
     }
 
     public static ArticleCommentResponse from(ArticleCommentDto dto) {
         String nickname = dto.userAccountDto().nickname();
         if(nickname == null || nickname.isBlank()) nickname = dto.userAccountDto().userId();
 
-        return new ArticleCommentResponse(dto.id(), dto.content(), dto.createdAt(), dto.userAccountDto().email(), nickname);
+        return new ArticleCommentResponse(dto.id(), dto.content(), dto.createdAt(), dto.userAccountDto().email(), nickname, dto.userAccountDto().userId());
     }
 }

--- a/src/main/java/com/fastcapmus/board/dto/response/ArticleWithCommentsResponse.java
+++ b/src/main/java/com/fastcapmus/board/dto/response/ArticleWithCommentsResponse.java
@@ -16,11 +16,12 @@ public record ArticleWithCommentsResponse(
         LocalDateTime createdAt,
         String email,
         String nickname,
+        String userId,
         Set<ArticleCommentResponse> articleCommentsResponse
 ) implements Serializable {
 
-    public static ArticleWithCommentsResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname, Set<ArticleCommentResponse> articleCommentResponses) {
-        return new ArticleWithCommentsResponse(id, title, content, hashtag, createdAt, email, nickname, articleCommentResponses);
+    public static ArticleWithCommentsResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname, String userId, Set<ArticleCommentResponse> articleCommentResponses) {
+        return new ArticleWithCommentsResponse(id, title, content, hashtag, createdAt, email, nickname, userId, articleCommentResponses);
     }
 
     public static ArticleWithCommentsResponse from(ArticleWithCommentsDto dto) {
@@ -37,6 +38,7 @@ public record ArticleWithCommentsResponse(
                 dto.createdAt(),
                 dto.userAccountDto().email(),
                 nickname,
+                dto.userAccountDto().userId(),
                 dto.articleCommentDtos().stream()
                         .map(ArticleCommentResponse::from)
                         .collect(Collectors.toCollection(LinkedHashSet::new))

--- a/src/main/java/com/fastcapmus/board/dto/security/BoardPrincipal.java
+++ b/src/main/java/com/fastcapmus/board/dto/security/BoardPrincipal.java
@@ -1,0 +1,91 @@
+package com.fastcapmus.board.dto.security;
+
+import com.fastcapmus.board.dto.UserAccountDto;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public record BoardPrincipal(
+        String username,
+        String password,
+        Collection<? extends GrantedAuthority> authorities,
+        String email,
+        String nickname,
+        String memo
+) implements UserDetails {
+
+    public static BoardPrincipal of(String username, String password, String email, String nickname, String memo) {
+        Set<RoleType> roleTypes = Set.of(RoleType.USER);
+
+        return new BoardPrincipal(
+                username,
+                password,
+                roleTypes.stream()
+                        .map(RoleType::getName)
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toUnmodifiableSet()),
+                email,
+                nickname,
+                memo
+        );
+    }
+
+    public static BoardPrincipal from(UserAccountDto userAccountDto) {
+        return BoardPrincipal.of(userAccountDto.userId(), userAccountDto.userPassword(), userAccountDto.email(), userAccountDto.nickname(), userAccountDto.memo());
+    }
+
+    public UserAccountDto toDto() {
+        return UserAccountDto.of(username, password, email, nickname, memo);
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    public enum RoleType{
+        USER("ROLE_USER");
+
+        @Getter
+        private final String name;
+
+        RoleType(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/src/main/java/com/fastcapmus/board/repository/ArticleCommentRepository.java
+++ b/src/main/java/com/fastcapmus/board/repository/ArticleCommentRepository.java
@@ -18,6 +18,8 @@ public interface ArticleCommentRepository extends JpaRepository<ArticleComment, 
 
     List<ArticleComment> findByArticle_Id(Long articleId);
 
+    void deleteByIdAndUserAccount_UserId(Long articleCommentId, String userId);
+
     @Override
     default void customize(QuerydslBindings bindings, QArticleComment root) {
         // 리스팅을 하지 않은 프로퍼티를 검색에서 제외하기 -> true로 변경(기본값 : false)

--- a/src/main/java/com/fastcapmus/board/repository/ArticleRepository.java
+++ b/src/main/java/com/fastcapmus/board/repository/ArticleRepository.java
@@ -23,6 +23,8 @@ public interface ArticleRepository extends JpaRepository<Article, Long>
     Page<Article> findByUserAccount_UserIdContaining(String userId, Pageable pageable);
     Page<Article> findByUserAccount_NicknameContaining(String nickname, Pageable pageable);
     Page<Article> findByHashtag(String hashtag, Pageable pageable);
+    void deleteByIdAndUserAccount_UserId(Long articleId, String userId);
+
     @Override
     default void customize(QuerydslBindings bindings, QArticle root){
         // 리스팅을 하지 않은 프로퍼티를 검색에서 제외하기 -> true로 변경(기본값 : false)

--- a/src/main/java/com/fastcapmus/board/repository/UserAccountRepository.java
+++ b/src/main/java/com/fastcapmus/board/repository/UserAccountRepository.java
@@ -2,6 +2,8 @@ package com.fastcapmus.board.repository;
 
 import com.fastcapmus.board.domain.UserAccount;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface UserAccountRepository extends JpaRepository<UserAccount, String> {
 }

--- a/src/main/java/com/fastcapmus/board/service/ArticleCommentService.java
+++ b/src/main/java/com/fastcapmus/board/service/ArticleCommentService.java
@@ -59,7 +59,7 @@ public class ArticleCommentService {
         }
     }
 
-    public void deleteArticleComment(Long articleCommentId) {
-        articleCommentRepository.deleteById(articleCommentId);
+    public void deleteArticleComment(Long articleCommentId, String userId) {
+        articleCommentRepository.deleteByIdAndUserAccount_UserId(articleCommentId, userId);
     }
 }

--- a/src/main/java/com/fastcapmus/board/service/ArticleService.java
+++ b/src/main/java/com/fastcapmus/board/service/ArticleService.java
@@ -68,19 +68,21 @@ public class ArticleService {
     public void updateArticle(Long articleId, ArticleDto dto) {
         try {
             Article article = articleRepository.getReferenceById(articleId);
+            UserAccount userAccount = userAccountRepository.getReferenceById(dto.userAccountDto().userId());
 
-            // not null 조건인 필드(컬럼)들은 null체크하는 방어 로직을 짜줘야 한다.
-            if (dto.title() != null) article.setTitle(dto.title());
-            if (dto.content() != null) article.setContent(dto.content());
-
-            article.setHashtag(dto.hashtag());
+            if (article.getUserAccount().equals(userAccount)) {
+                // not null 조건인 필드(컬럼)들은 null체크하는 방어 로직을 짜줘야 한다.
+                if (dto.title() != null) article.setTitle(dto.title());
+                if (dto.content() != null) article.setContent(dto.content());
+                article.setHashtag(dto.hashtag());
+            }
         } catch (EntityNotFoundException e) {
-            log.warn("게시글 수정 실패 : 해당 게시글을 찾을 수 없습니다. dto : {}", dto);
+            log.warn("게시글 수정 실패 : 해당 게시글을 수정하는데 필요한 정보를 찾을 수 없습니다. : {}", e.getLocalizedMessage());
         }
     }
 
-    public void deleteArticle(Long articleId) {
-        articleRepository.deleteById(articleId);
+    public void deleteArticle(Long articleId, String userId) {
+        articleRepository.deleteByIdAndUserAccount_UserId(articleId, userId);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -2,19 +2,19 @@
 -- TODO: 테스트용이지만 비밀번호가 노출된 데이터 세팅. 개선하는 것이 좋을 지 고민해 보자.
 insert into user_account (user_id, user_password, nickname, email, memo, created_at, created_by, modified_at,
                           modified_by)
-values ('hyunbenny1', 'hyunbenny1234', 'hyunbenny1', 'hyunbenny1@mail.com', 'I am hyunbenny1.', now(), 'hyunbenny1',
+values ('hyunbenny1', '{noop}hyunbenny1234', 'hyunbenny1', 'hyunbenny1@mail.com', 'I am hyunbenny1.', now(), 'hyunbenny1',
         now(), 'hyunbenny1')
 ;
 
 insert into user_account (user_id, user_password, nickname, email, memo, created_at, created_by, modified_at,
                           modified_by)
-values ('hyunbenny2', 'hyunbenny1234', 'hyunbenny2', 'hyunbenny2@mail.com', 'I am hyunbenny2.', now(), 'hyunbenny2',
+values ('hyunbenny2', '{noop}hyunbenny1234', 'hyunbenny2', 'hyunbenny2@mail.com', 'I am hyunbenny2.', now(), 'hyunbenny2',
         now(), 'hyunbenny2')
 ;
 
 insert into user_account (user_id, user_password, nickname, email, memo, created_at, created_by, modified_at,
                           modified_by)
-values ('hyunbenny3', 'hyunbenny1234', 'hyunbenny3', 'hyunbenny3@mail.com', 'I am hyunbenny3.', now(), 'hyunbenny3',
+values ('hyunbenny3', '{noop}hyunbenny1234', 'hyunbenny3', 'hyunbenny3@mail.com', 'I am hyunbenny3.', now(), 'hyunbenny3',
         now(), 'hyunbenny3')
 ;
 

--- a/src/main/resources/templates/articles/detail.html
+++ b/src/main/resources/templates/articles/detail.html
@@ -74,7 +74,7 @@
                                     Lorem ipsum dolor sit amet
                                 </p>
                             </div>
-                            <div class="col-2 mb-3">
+                            <div class="col-2 mb-3" align-self-center>
                                 <button type="submit" class="btn btn-outline-danger" id="delete-comment-button">삭제</button>
                             </div>
                         </div>
@@ -82,12 +82,17 @@
                 </li>
                 <li>
                     <div class="row">
-                        <strong>hyunbenny</strong>
-                        <small><time>2022-01-01</time></small>
-                        <p>
-                            Lorem ipsum dolor sit amet, consectetur adipiscing elit.<br>
-                            Lorem ipsum dolor sit amet
-                        </p>
+                        <div class="col-md-10 col-lg-9">
+                            <strong>hyunbenny</strong>
+                            <small><time>2022-01-01</time></small>
+                            <p>
+                                Lorem ipsum dolor sit amet, consectetur adipiscing elit.<br>
+                                Lorem ipsum dolor sit amet
+                            </p>
+                        </div>
+                        <div class="col-2 mb-3" align-self-center>
+                            <button type="submit" class="btn btn-outline-danger" hidden>삭제</button>
+                        </div>
                     </div>
                 </li>
             </ul>

--- a/src/main/resources/templates/articles/detail.th.xml
+++ b/src/main/resources/templates/articles/detail.th.xml
@@ -11,7 +11,7 @@
         <attr sel="#hashtag" th:text="*{hashtag}"/>
         <attr sel="#article-content/pre" th:text="*{content}"/>
 
-        <attr sel="#article-buttons">
+        <attr sel="#article-buttons" th:if="${#authorization.expression('isAuthenticated()')} and *{userId} == ${#authentication.name}">
             <attr sel="#delete-article-form" th:action="'/articles/' + *{id} + '/delete'" th:method="post">
                 <attr sel="#update-article" th:href="'/articles/' + *{id} + '/form'" />
             </attr>
@@ -28,6 +28,7 @@
                     <attr sel="div/strong" th:text="${articleComment.nickname}" />
                     <attr sel="div/small/time" th:datetime="${articleComment.createdAt}" th:text="${#temporals.format(articleComment.createdAt, 'yyyy-MM-dd HH:mm:ss')}" />
                     <attr sel="div/p" th:text="${articleComment.content}" />
+                    <attr sel="button" th:if="${#authorization.expression('isAuthenticated()')} and ${articleComment.userId} == ${#authentication.name}" />
                 </attr>
             </attr>
         </attr>

--- a/src/main/resources/templates/articles/index.th.xml
+++ b/src/main/resources/templates/articles/index.th.xml
@@ -60,7 +60,7 @@
             </attr>
         </attr>
 
-        <attr sel="#write-article" th:href="@{/articles/form}" />
+        <attr sel="#write-article" sec:authorize="isAuthenticated()" th:href="@{/articles/form}" />
 
         <attr sel="#pagination">
             <attr sel="li[0]/a"

--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -14,8 +14,9 @@
             </ul>
 
             <div class="text-end">
-                <button type="button" class="btn btn-outline-light me-2">LOGIN</button>
-                <button type="button" class="btn btn-warning">SIGNUP</button>
+                <span id="username" class="text-white me-2">username</span>
+                <a role="button" id="login" class="btn btn-outline-light me-2">LOGIN</a>
+                <a role="button" id="logout" class="btn btn-outline-light me-2">LOGOUT</a>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/header.th.xml
+++ b/src/main/resources/templates/header.th.xml
@@ -2,4 +2,8 @@
 <thlogic>
     <attr sel="#home" th:href="@{/}" />
     <attr sel="#hashtag" th:href="@{/articles/search-hashtag}" />
+    <attr sel="#username" sec:authorize="isAuthenticated()" sec:authentication="principal.nickname" />
+    <attr sel="#login" sec:authorize="!isAuthenticated()" th:href="@{/login}" />
+    <attr sel="#logout" sec:authorize="isAuthenticated()" th:href="@{/logout}" />
+
 </thlogic>

--- a/src/test/java/com/fastcapmus/board/config/TestSecurityConfig.java
+++ b/src/test/java/com/fastcapmus/board/config/TestSecurityConfig.java
@@ -1,0 +1,33 @@
+package com.fastcapmus.board.config;
+
+import com.fastcapmus.board.domain.UserAccount;
+import com.fastcapmus.board.repository.UserAccountRepository;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.event.annotation.BeforeTestMethod;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+@Import(SecurityConfig.class)
+public class TestSecurityConfig {
+
+    @MockBean
+    private UserAccountRepository userAccountRepository;
+
+    @BeforeTestMethod
+    public void securitySetup() {
+        given(userAccountRepository.findById(anyString()))
+                .willReturn(Optional.of(
+                        UserAccount.of("testuser",
+                                "testpassword",
+                                "test@mail.com",
+                                "testnickname",
+                                "testmemo"
+                        ))
+                );
+    }
+
+}

--- a/src/test/java/com/fastcapmus/board/controller/ArticleCommentControllerTest.java
+++ b/src/test/java/com/fastcapmus/board/controller/ArticleCommentControllerTest.java
@@ -1,6 +1,7 @@
 package com.fastcapmus.board.controller;
 
 import com.fastcapmus.board.config.SecurityConfig;
+import com.fastcapmus.board.config.TestSecurityConfig;
 import com.fastcapmus.board.dto.ArticleCommentDto;
 import com.fastcapmus.board.dto.request.ArticleCommentRequest;
 import com.fastcapmus.board.service.ArticleCommentService;
@@ -12,18 +13,21 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
+import static org.springframework.security.test.context.support.TestExecutionEvent.TEST_EXECUTION;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @DisplayName("View 컨트롤러 - 댓글")
-@Import({SecurityConfig.class, FormDataEncoder.class})
+@Import({TestSecurityConfig.class, FormDataEncoder.class})
 @WebMvcTest(ArticleCommentController.class)
 class ArticleCommentControllerTest {
 
@@ -39,6 +43,7 @@ class ArticleCommentControllerTest {
         this.formDataEncoder = formDataEncoder;
     }
 
+    @WithUserDetails(value = "testuser", userDetailsServiceBeanName = "userDetailsService", setupBefore = TEST_EXECUTION)
     @DisplayName("[view][POST] 댓글 등록 - 정상호출")
     @Test
     void givenArticleCommentInfo_whenRequest_thenSaveArticleComment() throws Exception {
@@ -61,14 +66,16 @@ class ArticleCommentControllerTest {
         then(articleCommentService).should().saveArticleComment(any(ArticleCommentDto.class));
     }
 
+    @WithUserDetails(value = "testuser", userDetailsServiceBeanName = "userDetailsService", setupBefore = TEST_EXECUTION)
     @DisplayName("[view][POST] 댓글 삭제 - 정상호출")
     @Test
     void givenArticleCommentIdToDelete_WhenRequest_thenDeletesArticleComment() throws Exception {
         // given
         long articleId = 1L;
         long articleCommentId = 1L;
+        String userId = "testuser";
 
-        willDoNothing().given(articleCommentService).deleteArticleComment(articleCommentId);
+        willDoNothing().given(articleCommentService).deleteArticleComment(articleCommentId, userId);
 
 
         //when then
@@ -81,7 +88,7 @@ class ArticleCommentControllerTest {
                 .andExpect(view().name("redirect:/articles/" + articleId))
                 .andExpect(redirectedUrl("/articles/" + articleId));
 
-        then(articleCommentService).should().deleteArticleComment(articleCommentId);
+        then(articleCommentService).should().deleteArticleComment(articleCommentId, userId);
     }
 
 

--- a/src/test/java/com/fastcapmus/board/controller/AuthControllerTest.java
+++ b/src/test/java/com/fastcapmus/board/controller/AuthControllerTest.java
@@ -1,6 +1,7 @@
 package com.fastcapmus.board.controller;
 
 import com.fastcapmus.board.config.SecurityConfig;
+import com.fastcapmus.board.config.TestSecurityConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,7 +16,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @DisplayName("AuthController - 인증")
-@Import(SecurityConfig.class)
+@Import(TestSecurityConfig.class)
 @WebMvcTest(Void.class)
 /**
  * /login 페이지는 직접 만든 컨트롤러가 아니고

--- a/src/test/java/com/fastcapmus/board/controller/MainControllerTest.java
+++ b/src/test/java/com/fastcapmus/board/controller/MainControllerTest.java
@@ -1,6 +1,7 @@
 package com.fastcapmus.board.controller;
 
 import com.fastcapmus.board.config.SecurityConfig;
+import com.fastcapmus.board.config.TestSecurityConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -11,7 +12,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@Import(SecurityConfig.class)
+@Import(TestSecurityConfig.class)
 @WebMvcTest(MainController.class)
 class MainControllerTest {
 

--- a/src/test/java/com/fastcapmus/board/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/fastcapmus/board/repository/JpaRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.fastcapmus.board.repository;
 
 import com.fastcapmus.board.config.JpaConfig;
+import com.fastcapmus.board.config.TestSecurityConfig;
 import com.fastcapmus.board.domain.Article;
 import com.fastcapmus.board.domain.UserAccount;
 import org.junit.jupiter.api.DisplayName;
@@ -8,16 +9,21 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
 //@ActiveProfiles("testdb")
 //@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE) // 자동으로 테스트DB를 띄우지 못하게 막는 어노테이션 -> 내가 설정한 테스트용 DB를 쓰게 하기 위해서
 @DisplayName("JPA 연결 테스트")
-@Import(JpaConfig.class)
+@Import(JpaRepositoryTest.TestJpaConfig.class)
 @DataJpaTest
 class JpaRepositoryTest {
     private final ArticleRepository articleRepository;
@@ -94,4 +100,16 @@ class JpaRepositoryTest {
         assertThat(articleCommentRepository.count()).isEqualTo(previousArticleCommentCount - deleteCommentSize);
 
     }
+
+    @EnableJpaAuditing
+    @TestConfiguration
+    public static class TestJpaConfig {
+
+        @Bean
+        public AuditorAware<String> auditorAware() {
+            return () -> Optional.of("hyunbenny");
+        }
+
+    }
+
 }

--- a/src/test/java/com/fastcapmus/board/service/ArticleCommentServiceTest.java
+++ b/src/test/java/com/fastcapmus/board/service/ArticleCommentServiceTest.java
@@ -147,13 +147,14 @@ class ArticleCommentServiceTest {
     void givenArticleCommentId_whenDeletingArticleComment_thenDeletesArticleComment() {
         // Given
         Long articleCommentId = 1L;
-        willDoNothing().given(articleCommentRepository).deleteById(articleCommentId);
+        String userId = "testuser";
+        willDoNothing().given(articleCommentRepository).deleteByIdAndUserAccount_UserId(articleCommentId, userId);
 
         // When
-        sut.deleteArticleComment(articleCommentId);
+        sut.deleteArticleComment(articleCommentId, userId);
 
         // Then
-        then(articleCommentRepository).should().deleteById(articleCommentId);
+        then(articleCommentRepository).should().deleteByIdAndUserAccount_UserId(articleCommentId, userId);
     }
 
 

--- a/src/test/java/com/fastcapmus/board/service/ArticleServiceTest.java
+++ b/src/test/java/com/fastcapmus/board/service/ArticleServiceTest.java
@@ -237,6 +237,7 @@ class ArticleServiceTest {
         ArticleDto dto = createArticleDto("new title", "new content", "#springboot");
 
         given(articleRepository.getReferenceById(dto.id())).willReturn(article);
+        given(userAccountRepository.getReferenceById(dto.userAccountDto().userId())).willReturn(dto.userAccountDto().toEntity());
 
         // When
         sut.updateArticle(dto.id(), dto);
@@ -248,6 +249,8 @@ class ArticleServiceTest {
                 .hasFieldOrPropertyWithValue("hashtag", dto.hashtag());
 
         then(articleRepository).should().getReferenceById(dto.id());
+        then(userAccountRepository).should().getReferenceById(dto.userAccountDto().userId());
+
     }
 
     @DisplayName("없는 게시글의 수정 정보를 입력하면, 경고 로그를 찍고 아무 것도 하지 않는다.")
@@ -273,14 +276,15 @@ class ArticleServiceTest {
          */
         // Given
         Long articleId = 1L;
-        willDoNothing().given(articleRepository).deleteById(articleId);
+        String userId = "hyunbenny";
+        willDoNothing().given(articleRepository).deleteByIdAndUserAccount_UserId(articleId, userId);
 
 
         // When
-        sut.deleteArticle(articleId);
+        sut.deleteArticle(articleId, userId);
 
         // Then
-        then(articleRepository).should().deleteById(articleId);
+        then(articleRepository).should().deleteByIdAndUserAccount_UserId(articleId, userId);
     }
 
     @DisplayName("게시글 수를 조회하면, 게시글 수를 반환한다.")


### PR DESCRIPTION
시큐리티 설정과 그에 따른 자바 코드 구현 및 테스트 수정
- JpaAuditing할 때, 회원 정보를 하드코딩 했었는데 SecurityContextHolder에서 정보를 가져오도록 수정함(JpaConfig)
- 시큐리티를 사용하여 로그인을 구현함에 따라 UserDetailService를 만들어 빈으로 등록하였고 이에 필요한 UserDetail를 구현한 BoardPrincipal을 작성함. 또한 게시글 목록, 해시태그 페이지를 제외한 모든 페이지는 인증을 필요로 하도록 필터체인 수정함(SecurityConfig, BoardPrincipal)
- 인증이 필요한 api에 대하여 BoardPrincipal 추가하고, 해당 유저가 아니면 게시글, 댓글이 수정, 삭제되지 않도록 방어로직 구현

구현한 인증기능을 바탕으로 뷰에서의 기능 구현
- 스프링부트 3점대를 사용함에 따른 타임리프 의존성 변경
- 테스트를 위한 더미데이터 등록시 패스워드 인코더가 평문이란 걸 인식할 수 있도록 insert쿼리문의 패스워드 데이터 앞에 `{noop}` 추가
- 게시글, 댓글 조회 시 수정, 삭제 버튼 노출여부를 판단할 때, 로그인한 회원과 작성자가 동일한지 확인을 위해 필요한 응답정보(userId)를 추가
- 게시글(글쓰기, 수정, 삭제), 댓글(삭제) 버튼이 작성자와 로그인한 사용자가 동일할 때만 노출되도록 구현
- 헤더에 로그인/로그아웃 버튼이 로그인 상태에 따라 변경되어 노출되도록 하였고, 로그인 시에는 userId가 같이 보여지도록 함.

This closes #31 