### PR TITLE
#54 [bug] 헤로쿠 DB 변경

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -66,6 +66,7 @@ spring:
     activate:
       on-profile: heroku
   databaseSource:
-    url: ${CLEARDB_DATABASE_URL}
+    url: ${JWASDB_URL}
+    driver-class-name: com.mysql.cj.jdbc.Driver
   jpa.hibernate.ddl-auto: create
   sql.init.mode: always


### PR DESCRIPTION
최초 헤로쿠 DB로 설정한 ClearDB가 지원하는 Mysql의 버전이 5.6임에 따라 
우리가 개발한 버전과 맞지 않아 mysql8을 지원하는 JwasDB로 변경함.(article_comment.content의 인덱스 사이즈가 너무 큼)
그에 따라 url설정 변경함

* https://devcenter.heroku.com/articles/cleardb#the-cleardb-dedicated-mysql-complete-tutorial-local-setup
* https://devcenter.heroku.com/articles/jawsdb#provisioning-with-custom-options

This closes #54