### PR TITLE
#73 [enhancement] 엔티티 리팩토링

### DIFF
--- a/src/main/java/com/fastcapmus/board/domain/Article.java
+++ b/src/main/java/com/fastcapmus/board/domain/Article.java
@@ -63,11 +63,11 @@ public class Article extends AuditingFields{
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof Article article)) return false;
-        return id != null && id.equals(article.id);
+        return this.getId() != null && this.getId().equals(article.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/com/fastcapmus/board/domain/ArticleComment.java
+++ b/src/main/java/com/fastcapmus/board/domain/ArticleComment.java
@@ -52,11 +52,11 @@ public class ArticleComment extends AuditingFields{
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof ArticleComment that)) return false;
-        return id != null && id.equals(that.id);
+        return this.getId() != null && this.getId().equals(that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/com/fastcapmus/board/domain/UserAccount.java
+++ b/src/main/java/com/fastcapmus/board/domain/UserAccount.java
@@ -58,11 +58,11 @@ public class UserAccount extends AuditingFields{
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof UserAccount userAccount)) return false;
-        return userId != null && userId.equals(userAccount.userId);
+        return this.getUserId() != null && this.getUserId().equals(userAccount.getUserId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId);
+        return Objects.hash(this.getUserId());
     }
 }


### PR DESCRIPTION
- 엔티티의 equals()와 hashcode()에서의 비교로직에서 필드에 직접 접근하는 부분이 있는데 지연로딩이 될 경우, 하이버네이트가 프록시 객체에 접근하여 필드 값이 `null`인 경우가 발생할 수 있다. 따라서 getter를 이용하여 프록시 객체이더라도 제대로 값을 받아올 수 있도록 함.

This closes #73 