### PR TITLE
Feature/#61 hashtag fun advancement

### DIFF
--- a/src/main/java/com/fastcapmus/board/controller/ArticleController.java
+++ b/src/main/java/com/fastcapmus/board/controller/ArticleController.java
@@ -55,6 +55,7 @@ public class ArticleController {
         modelMap.addAttribute("articles", articles);
         modelMap.addAttribute("paginationBarNumbers", barNumber);
         modelMap.addAttribute("searchTypes", SearchType.values());
+        modelMap.addAttribute("searchTypeHashtag", SearchType.HASHTAG);
 
         log.info(modelMap.get("articles").toString());
         return "articles/index";
@@ -67,6 +68,7 @@ public class ArticleController {
         modelMap.addAttribute("article", article);
         modelMap.addAttribute("articleComments", article.articleCommentsResponse());
         modelMap.addAttribute("totalCount", articleService.getArticleCount());
+        modelMap.addAttribute("searchTypeHashtag", SearchType.HASHTAG);
 
         return "articles/detail";
     }

--- a/src/main/java/com/fastcapmus/board/service/ArticleService.java
+++ b/src/main/java/com/fastcapmus/board/service/ArticleService.java
@@ -1,11 +1,13 @@
 package com.fastcapmus.board.service;
 
 import com.fastcapmus.board.domain.Article;
+import com.fastcapmus.board.domain.Hashtag;
 import com.fastcapmus.board.domain.UserAccount;
 import com.fastcapmus.board.domain.type.SearchType;
 import com.fastcapmus.board.dto.ArticleDto;
 import com.fastcapmus.board.dto.ArticleWithCommentsDto;
 import com.fastcapmus.board.repository.ArticleRepository;
+import com.fastcapmus.board.repository.HashtagRepository;
 import com.fastcapmus.board.repository.UserAccountRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +19,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -24,8 +28,10 @@ import java.util.List;
 @Service
 public class ArticleService {
 
+    private final HashtagService hashtagService;
     private final ArticleRepository articleRepository;
     private final UserAccountRepository userAccountRepository;
+    private final HashtagRepository hashtagRepository;
 
 
     @Transactional(readOnly = true)
@@ -63,9 +69,15 @@ public class ArticleService {
 
     public void saveArticle(ArticleDto dto) {
         UserAccount userAccount = userAccountRepository.getReferenceById(dto.userAccountDto().userId());
-        articleRepository.save(dto.toEntity(userAccount));
+        Set<Hashtag> hashtags = renewHashtagFromContent(dto.content());
+
+        Article article = dto.toEntity(userAccount);
+        article.addHashtags(hashtags);
+
+        articleRepository.save(article);
     }
 
+    @Transactional
     public void updateArticle(Long articleId, ArticleDto dto) {
         try {
             Article article = articleRepository.getReferenceById(articleId);
@@ -75,24 +87,62 @@ public class ArticleService {
                 // not null 조건인 필드(컬럼)들은 null체크하는 방어 로직을 짜줘야 한다.
                 if (dto.title() != null) article.setTitle(dto.title());
                 if (dto.content() != null) article.setContent(dto.content());
+
+                Set<Long> hashtagIds = article.getHashtags().stream()
+                        .map(hashtag -> hashtag.getId())
+                        .collect(Collectors.toUnmodifiableSet());
+
+                article.clearHashtags();
+                articleRepository.flush();
+
+                hashtagIds.forEach(hashtagService::deleteHashtagWithoutArticles);
+
+                Set<Hashtag> hashtags = renewHashtagFromContent(dto.content());
+                article.addHashtags(hashtags);
             }
         } catch (EntityNotFoundException e) {
             log.warn("게시글 수정 실패 : 해당 게시글을 수정하는데 필요한 정보를 찾을 수 없습니다. : {}", e.getLocalizedMessage());
         }
     }
 
+    @Transactional
     public void deleteArticle(Long articleId, String userId) {
+        Article article = articleRepository.getReferenceById(articleId);
+
+        Set<Long> hashtagIds = article.getHashtags().stream()
+                .map(hashtag -> hashtag.getId())
+                .collect(Collectors.toUnmodifiableSet());
+
         articleRepository.deleteByIdAndUserAccount_UserId(articleId, userId);
+        articleRepository.flush();
+
+        hashtagIds.forEach(hashtagService::deleteHashtagWithoutArticles);
     }
 
     @Transactional(readOnly = true)
-    public Page<ArticleDto> searchArticlesViaHashtag(String hashtag, Pageable pageable) {
-        if(hashtag == null || hashtag.isBlank()) return Page.empty(pageable);
+    public Page<ArticleDto> searchArticlesViaHashtag(String hashtagName, Pageable pageable) {
+        if(hashtagName == null || hashtagName.isBlank()) return Page.empty(pageable);
 
-        return articleRepository.findByHashtagNames(null, pageable).map(ArticleDto::from);
+        return articleRepository.findByHashtagNames(List.of(hashtagName), pageable)
+                .map(ArticleDto::from);
     }
 
     public List<String> getHashtags() {
-        return articleRepository.findAllDistinctHashtags();
+        return hashtagRepository.findAllHashtagNames(); // TODO : HashtagService를 통해서 결과를 제공받도록 수정해야 할 듯..
+    }
+
+    private Set<Hashtag> renewHashtagFromContent(String content) {
+        Set<String> hashtagNamesInContent = hashtagService.parseHashtagNames(content);
+        Set<Hashtag> hashtags = hashtagService.findHashtagsByNames(hashtagNamesInContent);
+
+        Set<String> existingHashtagNames = hashtags.stream()
+                .map(hashtag -> hashtag.getHashtagName())
+                .collect(Collectors.toUnmodifiableSet());
+
+        hashtagNamesInContent.forEach(newHashtagName -> {
+            if(!existingHashtagNames.contains(newHashtagName)) hashtags.add(Hashtag.of(newHashtagName));
+        });
+
+        return hashtags;
     }
 }

--- a/src/main/java/com/fastcapmus/board/service/HashtagService.java
+++ b/src/main/java/com/fastcapmus/board/service/HashtagService.java
@@ -1,18 +1,38 @@
 package com.fastcapmus.board.service;
 
+import com.fastcapmus.board.domain.Hashtag;
+import com.fastcapmus.board.repository.HashtagRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Service
+@RequiredArgsConstructor
 public class HashtagService {
 
-    public Object parseHashtagNames(String content) {
-        return null;
+    private final HashtagRepository hashtagRepository;
+
+    public Set<String> parseHashtagNames(String content) {
+        if(content == null) return Set.of();
+
+        Pattern pattern = Pattern.compile("#[\\w가-힣]+");
+        Matcher matcher = pattern.matcher(content.strip());
+        Set<String> result = new HashSet<>();
+        while (matcher.find()) {
+            result.add(matcher.group().replace("#", ""));
+        }
+
+        return Set.copyOf(result);
     }
-    public Object findHashtagsByNames(Set<String> expectedHashtagNames) {
-        return null;
+    public Set<Hashtag> findHashtagsByNames(Set<String> hashtagNames) {
+        return new HashSet<>(hashtagRepository.findByHashtagNameIn(hashtagNames));
     }
-    public void deleteHashtagWithoutArticles(Object any) {
+    public void deleteHashtagWithoutArticles(Long id) {
+        Hashtag hashtag = hashtagRepository.getReferenceById(id);
+        if(hashtag.getArticles().isEmpty()) hashtagRepository.deleteById(id);
     }
 }

--- a/src/main/resources/templates/articles/detail.html
+++ b/src/main/resources/templates/articles/detail.html
@@ -29,7 +29,7 @@
                 <p><span id="nickname">hyunbenny</span></p>
                 <p><a id="email" href="mailto:hyunbenny@gmail.com">hyunbenny@mail.com</a></p>
                 <p><time id="created-at" datetime="2022-01-01T00:00:00">2022-01-01</time></p>
-                <p><span id="hashtag">#java</span></p>
+                <p><span id="hashtag" class="badge text-bg-secondary mx-1"><a class="text-reset">#java</a></span></p>
             </aside>
         </section>
 

--- a/src/main/resources/templates/articles/detail.th.xml
+++ b/src/main/resources/templates/articles/detail.th.xml
@@ -8,7 +8,12 @@
         <attr sel="#nickname" th:text="*{nickname}"/>
         <attr sel="#email" th:text="*{email}"/>
         <attr sel="#created-at" th:datetime="*{createdAt}" th:text="*{#temporals.format(createdAt, 'yyyy-MM-dd HH:mm:ss')}"/>
-        <attr sel="#hashtag" th:text="*{hashtag}"/>
+        <attr sel="#hashtag" th:each="hashtag : ${article.hashtags}">
+            <attr sel="a"
+                  th:text="'#' + ${hashtag}"
+                  th:href="@{/articles(searchType=${searchTypeHashtag},searchValue=${hashtag})}"
+            />
+        </attr>
         <attr sel="#article-content/pre" th:text="*{content}"/>
 
         <attr sel="#article-buttons" th:if="${#authorization.expression('isAuthenticated()')} and *{userId} == ${#authentication.name}">

--- a/src/main/resources/templates/articles/form.html
+++ b/src/main/resources/templates/articles/form.html
@@ -35,12 +35,6 @@
         <textarea class="form-control" id="content" name="content" rows="5" required></textarea>
       </div>
     </div>
-    <div class="row mb-4 justify-content-md-center">
-      <label for="hashtag" class="col-sm-2 col-lg-1 col-form-label text-sm-end">해시태그</label>
-      <div class="col-sm-8 col-lg-9">
-        <input type="text" class="form-control" id="hashtag" name="hashtag">
-      </div>
-    </div>
     <div class="row mb-5 justify-content-md-center">
       <div class="col-sm-10 d-grid gap-2 d-sm-flex justify-content-sm-end">
         <button type="submit" class="btn btn-primary" id="submit-button">저장</button>

--- a/src/main/resources/templates/articles/form.th.xml
+++ b/src/main/resources/templates/articles/form.th.xml
@@ -8,7 +8,6 @@
     <attr sel="#article-form" th:action="${formStatus?.update} ? '/articles/' + ${article.id} + '/form' : '/articles/form'" th:method="post">
         <attr sel="#title" th:value="${article?.title} ?: _" />
         <attr sel="#content" th:text="${article?.content} ?: _" />
-        <attr sel="#hashtag" th:value="${article?.hashtag} ?: _" />
         <attr sel="#submit-button" th:text="${formStatus?.description} ?: _" />
         <attr sel="#cancel-button" th:onclick="'history.back()'" />
     </attr>

--- a/src/main/resources/templates/articles/index.th.xml
+++ b/src/main/resources/templates/articles/index.th.xml
@@ -54,11 +54,6 @@
                               th:href="@{/articles(searchType=${searchTypeHashtag},searchValue=${hashtag})}"
                         />
                     </attr>
-                        <attr sel="a"
-                              th:text="'#' + ${hashtag}"
-                              th:href="@{/articles(searchType=${searchTypeHashtag},searchValue=${hashtag})}"
-                        />
-                    </attr>
                     <attr sel="td.created-by" th:text="${article.nickname}" />
                     <attr sel="td.created-at/time" th:datetime="${article.createdAt}" th:text="${#temporals.format(article.createdAt, 'yyyy-MM-dd')}" />
                 </attr>

--- a/src/main/resources/templates/articles/index.th.xml
+++ b/src/main/resources/templates/articles/index.th.xml
@@ -27,7 +27,7 @@
                 )}"/>
                 <attr sel="th.hashtag/a" th:text="'해시태그'" th:href="@{/articles(
                     page=${articles.number},
-                    sort='hashtag' + (*{sort.getOrderFor('hashtag')} != null ? (*{sort.getOrderFor('hashtag').direction.name} != 'DESC' ? ',desc' : '') : ''),
+                    sort='hashtags' + (*{sort.getOrderFor('hashtags')} != null ? (*{sort.getOrderFor('hashtags').direction.name} != 'DESC' ? ',desc' : '') : ''),
                     searchType=${param.searchType},
                     searchValue=${param.searchValue}
                 )}"/>
@@ -48,7 +48,12 @@
             <attr sel="tbody" th:remove="all-but-first">
                 <attr sel="tr[0]" th:each="article : ${articles}">
                     <attr sel="td.title/a" th:text="${article.title}" th:href="@{'/articles/' + ${article.id}}" />
-                    <attr sel="td.hashtag/span" th:each="hashtag : ${article.hashtag}">
+                    <attr sel="td.hashtag/span" th:each="hashtag : ${article.hashtags}">
+                        <attr sel="a"
+                              th:text="'#' + ${hashtag}"
+                              th:href="@{/articles(searchType=${searchTypeHashtag},searchValue=${hashtag})}"
+                        />
+                    </attr>
                         <attr sel="a"
                               th:text="'#' + ${hashtag}"
                               th:href="@{/articles(searchType=${searchTypeHashtag},searchValue=${hashtag})}"

--- a/src/test/java/com/fastcapmus/board/service/ArticleServiceTest.java
+++ b/src/test/java/com/fastcapmus/board/service/ArticleServiceTest.java
@@ -227,18 +227,15 @@ class ArticleServiceTest {
         // Given
         String hashtagName = "java";
         Pageable pageable = Pageable.ofSize(20);
-
         Article expectedArticle = createArticle();
         given(articleRepository.findByHashtagNames(List.of(hashtagName), pageable))
                 .willReturn(new PageImpl<>(List.of(expectedArticle), pageable, 1));
-
 
         // When
         Page<ArticleDto> articles = sut.searchArticlesViaHashtag(hashtagName, pageable);
 
         // Then
-        assertThat(articles).isEmpty();
-        assertThat(articles).isEqualTo(new PageImpl<>(List.of(ArticleDto.from(expectedArticle), pageable, 1)));
+        assertThat(articles).isEqualTo(new PageImpl<>(List.of(ArticleDto.from(expectedArticle)), pageable, 1));
         then(articleRepository).should().findByHashtagNames(List.of(hashtagName), pageable);
     }
 

--- a/src/test/java/com/fastcapmus/board/service/HashtagServiceTest.java
+++ b/src/test/java/com/fastcapmus/board/service/HashtagServiceTest.java
@@ -1,0 +1,110 @@
+package com.fastcapmus.board.service;
+
+import com.fastcapmus.board.domain.Hashtag;
+import com.fastcapmus.board.repository.HashtagRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@DisplayName("비지니스로직 - 해시태그")
+@ExtendWith(MockitoExtension.class)
+class HashtagServiceTest {
+
+    @InjectMocks
+    private HashtagService sut;
+
+    @Mock
+    private HashtagRepository hashtagRepository;
+
+    @DisplayName("본문을 파싱하여 해시태그 이름들을 중복없이 반환한다.")
+    @MethodSource
+    @ParameterizedTest(name = "[{index}] \"{0}\" => {1}")
+    void givenContent_whenParsing_thenReturnUniqueHashtagNames(String content, Set<String> expected) {
+        // given
+
+        // when
+        Set<String> actual = sut.parseHashtagNames(content);
+
+        // then
+        assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
+        then(hashtagRepository).shouldHaveNoInteractions();
+    }
+
+    static Stream<Arguments> givenContent_whenParsing_thenReturnUniqueHashtagNames() {
+        return Stream.of(
+                arguments(null, Set.of()),
+                arguments("", Set.of()),
+                arguments("   ", Set.of()),
+                arguments("#", Set.of()),
+                arguments("  #", Set.of()),
+                arguments("#   ", Set.of()),
+                arguments("java", Set.of()),
+                arguments("java#", Set.of()),
+                arguments("ja#va", Set.of("va")),
+                arguments("#java", Set.of("java")),
+                arguments("#java_spring", Set.of("java_spring")),
+                arguments("#java-spring", Set.of("java")),
+                arguments("#_java_spring", Set.of("_java_spring")),
+                arguments("#-java-spring", Set.of()),
+                arguments("#_java_spring__", Set.of("_java_spring__")),
+                arguments("#java#spring", Set.of("java", "spring")),
+                arguments("#java #spring", Set.of("java", "spring")),
+                arguments("#java  #spring", Set.of("java", "spring")),
+                arguments("#java   #spring", Set.of("java", "spring")),
+                arguments("#java     #spring", Set.of("java", "spring")),
+                arguments("  #java     #spring ", Set.of("java", "spring")),
+                arguments("   #java     #spring   ", Set.of("java", "spring")),
+                arguments("#java#spring#부트", Set.of("java", "spring", "부트")),
+                arguments("#java #spring#부트", Set.of("java", "spring", "부트")),
+                arguments("#java#spring #부트", Set.of("java", "spring", "부트")),
+                arguments("#java,#spring,#부트", Set.of("java", "spring", "부트")),
+                arguments("#java.#spring;#부트", Set.of("java", "spring", "부트")),
+                arguments("#java|#spring:#부트", Set.of("java", "spring", "부트")),
+                arguments("#java #spring  #부트", Set.of("java", "spring", "부트")),
+                arguments("   #java,? #spring  ...  #부트 ", Set.of("java", "spring", "부트")),
+                arguments("#java#java#spring#부트", Set.of("java", "spring", "부트")),
+                arguments("#java#java#java#spring#부트", Set.of("java", "spring", "부트")),
+                arguments("#java#spring#java#부트#java", Set.of("java", "spring", "부트")),
+                arguments("#java#스프링 아주 긴 글~~~~~~~~~~~~~~~~~~~~~", Set.of("java", "스프링")),
+                arguments("아주 긴 글~~~~~~~~~~~~~~~~~~~~~#java#스프링", Set.of("java", "스프링")),
+                arguments("아주 긴 글~~~~~~#java#스프링~~~~~~~~~~~~~~~", Set.of("java", "스프링")),
+                arguments("아주 긴 글~~~~~~#java~~~~~~~#스프링~~~~~~~~", Set.of("java", "스프링"))
+        );
+    }
+
+    @DisplayName("해시태그 이름을 입력하면, 저장된 해시태그 중 이름에 매칭되는 것들을 중복없이 반환한다.")
+    @Test
+    void givenHashtagNames_whenFindingHashtags_thenReturnHashtagSet() {
+        // given
+        Set<String> hashtagNames = Set.of("java", "spring", "boots");
+        given(hashtagRepository.findByHashtagNameIn(hashtagNames)).willReturn(List.of(
+                Hashtag.of("java"),
+                Hashtag.of("spring")
+        ));
+
+        // when
+        Set<Hashtag> hashtags = sut.findHashtagsByNames(hashtagNames);
+
+        // then
+        assertThat(hashtags).hasSize(2);
+        then(hashtagRepository).should().findByHashtagNameIn(hashtagNames);
+
+    }
+
+
+}


### PR DESCRIPTION
해시태그 기능을 고도화하고 그에 따른 화면을 수정하였다.

하나의 글에 여러 개의 해시태그를 저장할 수 있고,
해시태그 입력을 따로 분리하지 않고 본문에서 해시태그(`#`)를 추출, 파싱해서 해시태그로 저장한다.
* DB에 저장할 때는 `#`은 빼고 문자열만 저장한다.

This closes #61 