### PR TITLE
[고도화] 댓글기능 고도화 - 대댓글: 도메인 업데이트

### DIFF
--- a/src/main/java/com/fastcapmus/board/domain/ArticleComment.java
+++ b/src/main/java/com/fastcapmus/board/domain/ArticleComment.java
@@ -5,7 +5,9 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
+import java.util.LinkedHashSet;
 import java.util.Objects;
+import java.util.Set;
 
 @Getter
 @ToString(callSuper = true)
@@ -32,20 +34,35 @@ public class ArticleComment extends AuditingFields{
     private UserAccount userAccount; // 유저 정보
 
     @Setter
+    @Column(nullable = true, updatable = false)
+    private Long parentCommentId; // 부모댓글(id)
+
+    @ToString.Exclude
+    @OrderBy("createdAt ASC")
+    @OneToMany(mappedBy = "parentCommentId", cascade = CascadeType.ALL)
+    private Set<ArticleComment> childComments = new LinkedHashSet<>();
+
+    @Setter
     @Column(nullable = false, length = 500)
     private String content; // 내용
 
     protected ArticleComment() {
     }
 
-    private ArticleComment(UserAccount userAccount, Article article, String content) {
+    private ArticleComment(UserAccount userAccount, Article article, Long parentCommentId, String content) {
         this.userAccount = userAccount;
         this.article = article;
+        this.parentCommentId = parentCommentId;
         this.content = content;
     }
 
     public static ArticleComment of(UserAccount userAccount, Article article, String content) {
-        return new ArticleComment(userAccount, article, content);
+        return new ArticleComment(userAccount, article, null, content);
+    }
+
+    public void addChildComment(ArticleComment child) {
+        child.setParentCommentId(this.id);
+        this.getChildComments().add(child);
     }
 
     @Override


### PR DESCRIPTION
1차 대댓글 기능을 위한 도메인 업데이트

대댓글 기능을 위해서 `ArticleComment` 도메인에 단방향 연관관계로 부모-자식관계를 파악할 수 있는 `parentCommentId`를 추가하였다. 그리고 이에 따라 자식 댓글들을 쉽게 사용할 수 있도록 `childComment`도 `Set`으로 추가하였다.
* `childComments`는 cascading 규칙을 모두 적용함.
* 부모댓글에서 자식댓글을 추가하는 방식을 사용하며 `addChildComment()`를 이용한다.

This closes #78 